### PR TITLE
[Fix] Wrong placement while dragging when front zposition is chosen

### DIFF
--- a/src/js/addons/jquery.mmenu.dragopen.js
+++ b/src/js/addons/jquery.mmenu.dragopen.js
@@ -218,7 +218,7 @@
 									$drag = $drag.add( that.$menu );
 									break;
 							}
-							$drag.css( that.opts.position, minMax( _distance, 10, _maxDistance ) );
+							$drag.css( that.opts.position, minMax( _distance, 10, _maxDistance ) - ('front' == that.opts.zposition ? _maxDistance : 0) );
 						}
 					}
 				)


### PR DESCRIPTION
The problem occurs when `zposition: 'front'` is being selected and is present on all sides of the screen. However, when the dragging ends the menu gets positioned correctly.

I am not committing the minified versions of the files because i am not using guard as deployment/tool in my projects and had some issues installing it with my current ruby setup.
