### PR TITLE
[Fix] webkitTransitionEnd not being fired

### DIFF
--- a/src/js/jquery.mmenu.js
+++ b/src/js/jquery.mmenu.js
@@ -792,7 +792,7 @@
 			})(),
 			_transitionEnd		= (function() {
 				var k;
-				return !(k = _transition) || tr[k];
+				return (k = _transition) && tr[k] ? tr[k] : false;
 			})(),
 			_oldAndroidBrowser	= (function() {
 				if ( ua.indexOf( 'Android' ) >= 0 )


### PR DESCRIPTION
I have run into this issue on all Android devices i have worked with (Chrome browser).

I am not committing the minified versions of the files because i am not using guard as deployment/tool in my projects and had some issues installing it with my current ruby setup.
