### PR TITLE
Fix Gulp merge-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
   ],
   "license": "CC-BY-NC-4.0",
   "devDependencies": {
+    "event-stream": "^0.2.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
-    "gulp-concat": "^2.6.0",
     "gulp-clean-css": "^2.0.13",
+    "gulp-concat": "^2.6.0",
     "gulp-rename": "^1.2.2",
     "gulp-ruby-sass": "^2.0.6",
     "gulp-uglify": "^1.5.1",
     "gulp-umd": "^0.2.0",
-    "event-stream": "^0.2.0"
+    "merge-stream": "^1.0.1"
   }
 }


### PR DESCRIPTION
With v6.0.0, it misses a dependency to use Gulp

```javascript
module.js:472
    throw err;
    ^

Error: Cannot find module 'merge-stream'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (d:\Profiles\qpollet\Documents\Contributing\jQuery.mmenu\gulpfile.js:22:10)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
```