### PR TITLE
Changed 'children' to 'find' in Bootstrap wrapper

### DIFF
--- a/src/wrappers/bootstrap/jquery.mmenu.bootstrap.ts
+++ b/src/wrappers/bootstrap/jquery.mmenu.bootstrap.ts
@@ -1,4 +1,4 @@
-/*	
+/*
  * Bootstrap wrapper for jQuery mmenu
  * Include this file after including the jquery.mmenu plugin for default Bootstrap tabs, pills and navbar support.
  */
@@ -25,7 +25,7 @@
 
 		for ( var t = 0; t < types.length; t++ )
 		{
-			if ( $menu.children( '.' + types[ t ] ).length )
+			if ( $menu.find( '.' + types[ t ] ).length )
 			{
 				_type = types[ t ];
 				break;
@@ -73,7 +73,7 @@
 						$(this).replaceWith( '<span>' + $(this).html() + '</span>' );
 					}
 				);
-			
+
 			$dropdown
 				.children( '.dropdown-menu' )
 				.removeClass( 'dropdown-menu' );
@@ -114,6 +114,6 @@
 				});
 		}
 	};
-	
+
 
 })( jQuery );


### PR DESCRIPTION
I'm experimenting with the Bootstrap wrapper and a Bootstrap Drupal theme and noticed that the toggle icon wasn't getting the proper handler assigned to it. This is because the Drupal theme adds more divs around the navbar-nav list and therefore isn't a direct child of the navbar-collapse element.

This pull request switches to using 'find' rather than 'children' to search deeper in the nested elements for the navbar-nav class.

I think my IDE also cleaned up some whitespace but the main change is on line 28.