### PR TITLE
fix typo

### DIFF
--- a/src/addons/iconpanels/jquery.mmenu.iconpanels.scss
+++ b/src/addons/iconpanels/jquery.mmenu.iconpanels.scss
@@ -19,12 +19,12 @@
 		~ .mm-panel,
 		~ .mm-panel_opened ~ .mm-listview_fixeddivider
 		{
-			width: calc( 100% - $mm_iconpanelSize ); //	IE11 fallback
+			width: calc( 100% - #{$mm_iconpanelSize} ); //	IE11 fallback
 			width: calc( 100% - var( --mm-iconpanel-size ) );
 		}
 	}
 
-	.mm-menu_iconpanel .mm-panels 
+	.mm-menu_iconpanel .mm-panels
 	{
 		> .mm-panel,
 		> .mm-listview_fixeddivider

--- a/src/addons/sidebar/jquery.mmenu.sidebar.scss
+++ b/src/addons/sidebar/jquery.mmenu.sidebar.scss
@@ -44,7 +44,7 @@
 
 @if ( $mm_opt_sidebar_collapsed )
 {
-	.mm-wrapper_sidebar-collapsed:not( .mm-wrapper_opening ) 
+	.mm-wrapper_sidebar-collapsed:not( .mm-wrapper_opening )
 	{
 		.mm-menu_hidenavbar .mm-navbar,
 		.mm-menu_hidedivider .mm-listitem_divider
@@ -116,7 +116,7 @@
 			{
 				~ .mm-slideout
 				{
-					width: calc( 100% - #{mm_sidebarExpandedSize} ); //	IE11 fallback
+					width: calc( 100% - #{$mm_sidebarExpandedSize} ); //	IE11 fallback
 					width: calc( 100% - var( --mm-sidebar-expanded-size ) );
 
 					transform: translate3d( $mm_sidebarExpandedSize, 0, 0 ); //	IE11 fallback


### PR DESCRIPTION
Fix sass interpolation's typos, which breaks syntax in distributive css files.

I'm trying to build myself, but recieve a wierd result in all css files:
- autopriefixer added a lot of unnecessary vendor properties
- values for css variables - Instead of values, the sass variable names remain

So I edited only source sass files