### PR TITLE
Fix translation task never finishing if no translations in build file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -256,7 +256,7 @@ gulp.task( 'js-compile', function() {
 });
 
 //	2)	Compile translations
-gulp.task( 'js-translations', [ 'js-compile' ], function() {
+gulp.task( 'js-translations', [ 'js-compile' ], function(cb) {
 
 	var streams = [],
 		stream;
@@ -282,7 +282,11 @@ gulp.task( 'js-translations', [ 'js-compile' ], function() {
 		streams.push( stream );
 	}
 
-	return merge.apply( this, streams );
+	if(build.files.translations.length > 0){
+		return merge.apply( this, streams );
+	} else {
+		cb();
+	}
 });
 
 //	3) 	Concatenate JS


### PR DESCRIPTION
If you provide a custom `_build.json` with no translations, the `js-translations` task never completes because it doesn't return a stream. That means the `js-concat` task never runs so dist never gets any generated `js` files.

I've worked around this by using a callback if there are no translations specified. I'm sure there's a better way to handle this so feel free to amend.