### PR TITLE
Copy listview toggle's classes to generated open link in case of span

### DIFF
--- a/src/core/oncanvas/jquery.mmenu.oncanvas.ts
+++ b/src/core/oncanvas/jquery.mmenu.oncanvas.ts
@@ -733,7 +733,7 @@
 					$b.insertAfter( $a );
 					if ( $a.is( 'span' ) )
 					{
-						$b.addClass( _c.listitem + '__text' ).html( $a.html() );
+						$b.addClass( _c.listitem + '__text ' + $a.attr('class') ).html( $a.html() );
 						$a.remove();
 					}
 				}


### PR DESCRIPTION
In the case:
```
...
<li><span class="foo">About us</span>
	<ul>
		<li><a href="#/">History</a></li>
		<li><a href="#/">Our address</a></li>
	</ul>
</li>
...
```
Open link will appear as:
```
<a class="mm-btn mm-btn_next mm-listitem__btn mm-listitem__text" href="#mm-0" aria-owns="mm-0" aria-haspopup="true">
	About us
	<span class="mm-sronly">Open submenu</span>
</a>
```
So the class 'foo' was lost. This commit fixing that.