### PR TITLE
Make dropdown tip visible again

### DIFF
--- a/src/addons/dropdown/jquery.mmenu.dropdown.scss
+++ b/src/addons/dropdown/jquery.mmenu.dropdown.scss
@@ -8,7 +8,8 @@
 	.mm-menu_dropdown
 	{
 		box-shadow: $mm_dropdownShadow;
-		height: percentage( $mm_menuHeight );	
+		height: percentage( $mm_menuHeight );
+		overflow: visible;
 	}
 
 	.mm-wrapper_dropdown


### PR DESCRIPTION
Dropdown tip visibility was dropped due to this changes https://github.com/FrDH/jQuery.mmenu/commit/abef33d0a70a539d2669dd4a94c2c72b18af267a#diff-f0b52ed69a3900cc653d862db8f96c3a